### PR TITLE
Ensure that max-line-length works from the command-line

### DIFF
--- a/src/bikeshed/core.clj
+++ b/src/bikeshed/core.clj
@@ -51,7 +51,7 @@
   "Complain about lines longer than <max-line-length> characters.
   max-line-length defaults to 80."
   [all-dirs & {:keys [max-line-length] :or {max-line-length 80}}]
-  (printf "\nChecking for lines longer than %s characters." max-line-length)
+  (printf "\nChecking for lines longer than %s characters.\n" max-line-length)
   (let [max-line-length (inc max-line-length)
         cmd (str "find " all-dirs " -name "
                  "'*.clj' | xargs egrep -H -n '^.{" max-line-length ",}$'")


### PR DESCRIPTION
When using `lein bikeshed -m 1000` from the terminal I get the following:

```
Checking for lines longer than 1000 characters.Exception in thread "main" java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
    at clojure.lang.Numbers.inc(Numbers.java:110)
    at bikeshed.core$long_lines.doInvoke(core.clj:55)
    at clojure.lang.RestFn.invoke(RestFn.java:439)
    at bikeshed.core$bikeshed.doInvoke(core.clj:153)
    at clojure.lang.RestFn.invoke(RestFn.java:423)
    at user$eval516.invoke(form-init8153822776944165599.clj:1)
    at clojure.lang.Compiler.eval(Compiler.java:6619)
    at clojure.lang.Compiler.eval(Compiler.java:6609)
    at clojure.lang.Compiler.load(Compiler.java:7064)
    at clojure.lang.Compiler.loadFile(Compiler.java:7020)
    at clojure.main$load_script.invoke(main.clj:294)
    at clojure.main$init_opt.invoke(main.clj:299)
    at clojure.main$initialize.invoke(main.clj:327)
    at clojure.main$null_opt.invoke(main.clj:362)
    at clojure.main$main.doInvoke(main.clj:440)
    at clojure.lang.RestFn.invoke(RestFn.java:421)
    at clojure.lang.Var.invoke(Var.java:419)
    at clojure.lang.AFn.applyToHelper(AFn.java:163)
    at clojure.lang.Var.applyTo(Var.java:532)
    at clojure.main.main(main.java:37)
Subprocess failed
```

These two commits solve this exception and also tidies up the formatting of the first line.
