### PR TITLE
Add missing newline

### DIFF
--- a/src/bikeshed/core.clj
+++ b/src/bikeshed/core.clj
@@ -51,7 +51,7 @@
   "Complain about lines longer than <max-line-length> characters.
   max-line-length defaults to 80."
   [all-dirs & {:keys [max-line-length] :or {max-line-length 80}}]
-  (printf "\nChecking for lines longer than %s characters." max-line-length)
+  (printf "\nChecking for lines longer than %s characters.\n" max-line-length)
   (let [max-line-length (inc max-line-length)
         cmd (str "find " all-dirs " -name "
                  "'*.clj' | xargs egrep -H -n '^.{" max-line-length ",}$'")


### PR DESCRIPTION
Just adds in a newline so that output matches README. 

That is:

```
Checking for lines longer than 80 characters.Badly formatted files:
```

becomes

```
Checking for lines longer than 80 characters.
Badly formatted files:
```
