### PR TITLE
Provide a help summary in lein help

### DIFF
--- a/src/leiningen/bikeshed.clj
+++ b/src/leiningen/bikeshed.clj
@@ -1,8 +1,10 @@
 (ns leiningen.bikeshed
   (:require [leiningen.core.eval :as lein]))
 
+(defn help []
+  "Bikesheds your project with totally arbitrary criteria.")
+
 (defn bikeshed [project & args]
-  "Bikesheds your project with totally arbitrary criteria."
   (lein/eval-in-project
    (-> project
        (update-in [:dependencies] conj ['lein-bikeshed "0.1.8-SNAPSHOT"]))


### PR DESCRIPTION
The help summary for the bikeshed task doesn't show up in `lein help`. This commit fixes that.

Or rather, this:

```
$ lein
Leiningen is a tool for working with Clojure projects.

Several tasks are available:
ancient             Check your Project for outdated Dependencies.
bikeshed
change              Rewrite project.clj by applying a function.
check               Check syntax and warn on reflection.
```

turns into:

```
$ lein help
Leiningen is a tool for working with Clojure projects.

Several tasks are available:
ancient             Check your Project for outdated Dependencies.
bikeshed            Bikesheds your project with totally arbitrary criteria.
change              Rewrite project.clj by applying a function.
check               Check syntax and warn on reflection.
```
