### PR TITLE
do not show weird NaN% when project have no docs

### DIFF
--- a/src/bikeshed/core.clj
+++ b/src/bikeshed/core.clj
@@ -155,7 +155,7 @@
           (* 100 (/ (- (count all-publics)
                        (count no-docstrings))
                     (count all-publics))))
-         (catch ArithmeticException _ Double/NaN)))
+         (catch ArithmeticException _ 0)))
       (flush)
       (when verbose
         (println "\nMethods without docstrings:")


### PR DESCRIPTION
This change fixes buggy behavior in case project have no docstrings at all.
Current message is:
`0/0 [NaN%] functions have docstrings.`
Will be:
`0/0 [0%] functions have docstrings.`