### PR TITLE
Option to ignore files not in git

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ Checking for arguments colliding with clojure.core functions.
 
 ## Options
 
-| Switches                    | Default | Desc                        |
-| --------------------------- | ------- | --------------------------- |
-| -H, --no-help-me, --help-me | false   | Show help                   |
-| -v, --no-verbose, --verbose | false   | Display missing doc strings |
-| -m, --max-line-length       |         | Max line length             |
+| Switches                    | Default | Desc                               |
+| --------------------------- | ------- | ---------------------------------- |
+| -H, --no-help-me, --help-me | false   | Show help                          |
+| -v, --no-verbose, --verbose | false   | Display missing doc strings        |
+| -m, --max-line-length       |         | Max line length                    |
+| -c, --only-git-checked      | false   | Lint files that are checked in git |
 
 ## License
 

--- a/src/leiningen/bikeshed.clj
+++ b/src/leiningen/bikeshed.clj
@@ -21,14 +21,17 @@
             :flag true :default false]
            ["-m" "--max-line-length" "Max line length"
             :default nil
-            :parse-fn #(Integer/parseInt %)])]
+            :parse-fn #(Integer/parseInt %)]
+           ["-c" "--only-git-checked" "Only lint files that are checked in git"
+            :flag true :default false])]
       '~project
       (when (:help-me opts#)
         (println banner#)
         (System/exit 0))
       (if (bikeshed.core/bikeshed
            '~project {:max-line-length (:max-line-length opts#)
-                      :verbose (:verbose opts#)})
+                      :verbose (:verbose opts#)
+                      :only-git-checked? (:only-git-checked opts#)})
         (System/exit -1)
         (System/exit 0)))
    '(do


### PR DESCRIPTION
Rationale: I have many "messy" files that are not checked in git (typically living in `:profiles :dev :source-paths`) & I don't want to lint them until I have checked them in git.

This PR adds a new `-c` flag that ignores source files that are not tracked by git.

