### PR TITLE
use `filename-regex` as a gnu find regex

### DIFF
--- a/src/bikeshed/core.clj
+++ b/src/bikeshed/core.clj
@@ -49,7 +49,8 @@
 
 (def filename-regex
   "Gnu `find' regex for files that should be checked"
-  "'*.clj*'")
+  ;; double escape characters: one for clojure, one for gnu find
+  "'.*\\.clj[scx]{0,1}'")
 
 (defn load-namespace
   "Reads a file, returning the namespace name"
@@ -97,7 +98,7 @@
   [all-dirs & {:keys [max-line-length] :or {max-line-length 80}}]
   (printf "\nChecking for lines longer than %s characters.\n" max-line-length)
   (let [max-line-length (inc max-line-length)
-        cmd (str "find " all-dirs " -name "
+        cmd (str "find " all-dirs " find -regextype posix-extended -regex "
                  filename-regex
                  " | xargs egrep -H -n '^.{" max-line-length ",}$'")
         out (:out (clojure.java.shell/sh "bash" "-c" cmd))
@@ -112,7 +113,7 @@
   "Complain about lines with trailing whitespace."
   [all-dirs]
   (println "\nChecking for lines with trailing whitespace.")
-  (let [cmd (str "find " all-dirs " -name "
+  (let [cmd (str "find " all-dirs " find -regextype posix-extended -regex "
                  filename-regex " | xargs grep -H -n '[ \t]$'")
         out (:out (clojure.java.shell/sh "bash" "-c" cmd))
         your-code-is-formatted-wrong (not (blank? out))]
@@ -126,7 +127,7 @@
   "Complain about files ending with blank lines."
   [all-dirs]
   (println "\nChecking for files ending in blank lines.")
-  (let [cmd (str "find " all-dirs " -name " filename-regex " "
+  (let [cmd (str "find " all-dirs " find -regextype posix-extended -regex " filename-regex " "
                  "-exec tail -1 \\{\\} \\; -print "
                  "| egrep -A 1 '^\\s*$' | egrep 'clj|sql'")
         out (:out (clojure.java.shell/sh "bash" "-c" cmd))
@@ -141,7 +142,7 @@
   "Complain about the use of with-redefs."
   [source-dirs]
   (println "\nChecking for redefined var roots in source directories.")
-  (let [cmd (str "find " source-dirs " -name " filename-regex " | "
+  (let [cmd (str "find " source-dirs " find -regextype posix-extended -regex " filename-regex " | "
                  "xargs egrep -H -n '(\\(with-redefs)'")
         out (:out (clojure.java.shell/sh "bash" "-c" cmd))
         lines (line-seq (BufferedReader. (StringReader. out)))]

--- a/src/bikeshed/core.clj
+++ b/src/bikeshed/core.clj
@@ -98,7 +98,7 @@
   [all-dirs & {:keys [max-line-length] :or {max-line-length 80}}]
   (printf "\nChecking for lines longer than %s characters.\n" max-line-length)
   (let [max-line-length (inc max-line-length)
-        cmd (str "find " all-dirs " find -regextype posix-extended -regex "
+        cmd (str "find " all-dirs " -regextype posix-extended -regex "
                  filename-regex
                  " | xargs egrep -H -n '^.{" max-line-length ",}$'")
         out (:out (clojure.java.shell/sh "bash" "-c" cmd))
@@ -113,7 +113,7 @@
   "Complain about lines with trailing whitespace."
   [all-dirs]
   (println "\nChecking for lines with trailing whitespace.")
-  (let [cmd (str "find " all-dirs " find -regextype posix-extended -regex "
+  (let [cmd (str "find " all-dirs " -regextype posix-extended -regex "
                  filename-regex " | xargs grep -H -n '[ \t]$'")
         out (:out (clojure.java.shell/sh "bash" "-c" cmd))
         your-code-is-formatted-wrong (not (blank? out))]
@@ -127,7 +127,7 @@
   "Complain about files ending with blank lines."
   [all-dirs]
   (println "\nChecking for files ending in blank lines.")
-  (let [cmd (str "find " all-dirs " find -regextype posix-extended -regex " filename-regex " "
+  (let [cmd (str "find " all-dirs " -regextype posix-extended -regex " filename-regex " "
                  "-exec tail -1 \\{\\} \\; -print "
                  "| egrep -A 1 '^\\s*$' | egrep 'clj|sql'")
         out (:out (clojure.java.shell/sh "bash" "-c" cmd))
@@ -142,7 +142,7 @@
   "Complain about the use of with-redefs."
   [source-dirs]
   (println "\nChecking for redefined var roots in source directories.")
-  (let [cmd (str "find " source-dirs " find -regextype posix-extended -regex " filename-regex " | "
+  (let [cmd (str "find " source-dirs " -regextype posix-extended -regex " filename-regex " | "
                  "xargs egrep -H -n '(\\(with-redefs)'")
         out (:out (clojure.java.shell/sh "bash" "-c" cmd))
         lines (line-seq (BufferedReader. (StringReader. out)))]

--- a/src/bikeshed/core.clj
+++ b/src/bikeshed/core.clj
@@ -50,7 +50,7 @@
 (def filename-regex
   "Gnu `find' regex for files that should be checked"
   ;; double escape characters: one for clojure, one for gnu find
-  "'.*\\.clj[scx]{0,1}'")
+  "'.*\\.clj[scx]?'")
 
 (defn load-namespace
   "Reads a file, returning the namespace name"


### PR DESCRIPTION
AOT a wildcard pattern argument for the `-name` option

I wanted this to prevent it from matching files that aren't actually clojure sources. The `gnu find` "wildcard pattern" stuff is not able to match just `*.clj[scx]{0,1}` so I switched it to regular expressions.