### PR TITLE
Add profile exclusions

### DIFF
--- a/src/leiningen/bikeshed.clj
+++ b/src/leiningen/bikeshed.clj
@@ -1,5 +1,6 @@
 (ns leiningen.bikeshed
-  (:require [leiningen.core.eval :as lein]))
+  (:require [clojure.tools.cli :as cli]
+            [leiningen.core.eval :as lein]))
 
 (defn help
   "Help text displayed from the command line"
@@ -9,28 +10,26 @@
 (defn bikeshed
   "Main function called from Leiningen"
   [project & args]
-  (lein/eval-in-project
-   (-> project
-       (update-in [:dependencies] conj ['lein-bikeshed "0.3.1-SNAPSHOT"]))
-   `(let [[opts# args# banner#]
-          (clojure.tools.cli/cli
-           '~args
-           ["-H" "--help-me" "Show help"
-            :flag true :default false]
-           ["-v" "--verbose" "Display missing doc strings"
-            :flag true :default false]
-           ["-m" "--max-line-length" "Max line length"
-            :default nil
-            :parse-fn #(Integer/parseInt %)])]
-      '~project
-      (when (:help-me opts#)
-        (println banner#)
-        (System/exit 0))
-      (if (bikeshed.core/bikeshed
-           '~project {:max-line-length (:max-line-length opts#)
-                      :verbose (:verbose opts#)})
-        (System/exit -1)
-        (System/exit 0)))
-   '(do
-      (require 'bikeshed.core)
-      (require 'clojure.tools.cli))))
+  (let [[opts args banner]
+        (cli/cli
+         args
+         ["-H" "--help-me" "Show help"
+          :flag true :default false]
+         ["-v" "--verbose" "Display missing doc strings"
+          :flag true :default false]
+         ["-m" "--max-line-length" "Max line length"
+          :default nil
+          :parse-fn #(Integer/parseInt %)])]
+    (if (:help-me opts)
+      (println banner)
+      (lein/eval-in-project
+       (-> project
+           (update-in [:dependencies]
+                      conj
+                      ['lein-bikeshed "0.3.1-SNAPSHOT"]))
+       `(if (bikeshed.core/bikeshed
+             '~project
+             (select-keys ~opts [:max-line-length :verbose]))
+          (System/exit -1)
+          (System/exit 0))
+       '(require 'bikeshed.core)))))


### PR DESCRIPTION
Adds a new command-line option `-x` that accepts a comma-separated list of profiles whose source directories will be excluded from processing. The primary use case would be to exempt the `user.clj` file in the `:dev` profile from bikeshed checks.