### PR TITLE
Make Windows-friendly

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,5 +5,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in :leiningen
-  :dependencies [[org.clojure/tools.cli       "0.3.1"]
-                 [org.clojure/tools.namespace "0.2.6"]])
+  :dependencies [[org.clojure/tools.namespace "0.2.6"]])

--- a/test/bikeshed/core_test.clj
+++ b/test/bikeshed/core_test.clj
@@ -11,7 +11,7 @@
 
 (def a "≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡")
 
-lot's of extra newlines:
+;; lot's of extra newlines:
 
 
 

--- a/test/bikeshed/core_test.cljs
+++ b/test/bikeshed/core_test.cljs
@@ -8,7 +8,7 @@
 
 (def a "≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡")
 
-lot's of extra newlines:
+;; lot's of extra newlines:
 
 
 


### PR DESCRIPTION
lein-bikeshed does not run on Windows, but with these small tweaks it does.  Bonus: removes the cli dep.