### PR TITLE
provide toggles for linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,14 @@ Checking for arguments colliding with clojure.core functions.
 | --------------------------- | ------- | --------------------------- |
 | -H, --no-help-me, --help-me | false   | Show help                   |
 | -v, --no-verbose, --verbose | false   | Display missing doc strings |
-| -m, --max-line-length       |         | Max line length             |
-| -x, --exclude-profiles |        | Comma-separated profile exclusion |
+| -m, --max-line-length       | 80      | Max line length             |
+| -l, --long-lines            | true    | Check for lines with length > max line length |
+| -w, --trailing-whitespace   | true    | Check for trailing whitespace |
+| -b, --trailing-blank-lines  | true    | Check for trailing blank lines |
+| -r, --var-redefs            | true    | Check for redefined root vars |
+| -d, --docstrings            | true    | Generate a report of docstring coverage |
+| -n, --name-collisions       | true    | Check for function arg names that collide with clojure.core |
+| -x, --exclude-profiles      |         | Comma-separated profile exclusion |
 
 You can also add the `:bikeshed` option map directly to your `project.clj`:
 
@@ -58,7 +64,9 @@ You can also add the `:bikeshed` option map directly to your `project.clj`:
 (defproject my-thing "1.0.0"
   :description "A thing"
   ;; Override the default max-line-length
-  :bikeshed {:max-line-length 60}
+  :bikeshed {:max-line-length 60
+             :var-redefs false
+             :name-collisions false}
   :dependencies [[clj-http "3.3.0"]])
 ```
 

--- a/src/leiningen/bikeshed.clj
+++ b/src/leiningen/bikeshed.clj
@@ -20,8 +20,25 @@
          ["-v" "--verbose" "Display missing doc strings"
           :flag true :default false]
          ["-m" "--max-line-length" "Max line length"
-          :default nil
           :parse-fn #(Integer/parseInt %)]
+         ["-l" "--long-lines"
+          "If true, check for trailing blank lines"
+          :parse-fn #(Boolean/valueOf %)]
+         ["-w" "--trailing-whitespace"
+          "If true, check for trailing whitespace"
+          :parse-fn #(Boolean/valueOf %)]
+         ["-b" "--trailing-blank-lines"
+          "If true, check for trailing blank lines"
+          :parse-fn #(Boolean/valueOf %)]
+         ["-r" "--var-redefs"
+          "If true, check for redefined var roots in source directories"
+          :parse-fn #(Boolean/valueOf %)]
+         ["-d" "--docstrings"
+          "If true, generate a report of docstring coverage"
+          :parse-fn #(Boolean/valueOf %)]
+         ["-n" "--name-collisions"
+          "If true, check for function arg names that collide with clojure.core"
+          :parse-fn #(Boolean/valueOf %)]
          ["-x" "--exclude-profiles" "Comma-separated profile exclusions"
           :default nil
           :parse-fn #(mapv keyword (str/split % #","))])
@@ -42,8 +59,8 @@
              '~project
              {:max-line-length (or (:max-line-length ~opts)
                                    (:max-line-length ~lein-opts))
-              :verbose (:verbose ~opts)}
-             (select-keys ~opts [:max-line-length :verbose]))
+              :verbose         (:verbose ~opts)
+              :check?          #(get (merge ~lein-opts ~opts) % true)})
           (System/exit -1)
           (System/exit 0))
        '(require 'bikeshed.core)))))


### PR DESCRIPTION
- add CLI and project-level configuration to toggle each of the linters
- CLI-based toggles override project-level ones
- log success or failures

e.g.
```
The following checks failed:
 * long-lines
 * var-redefs

Subprocess failed
```