### PR TITLE
Add org.clojure/tools.cli dependency back

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in :leiningen
-  :dependencies [[org.clojure/tools.namespace "0.2.6"]])
+  :dependencies [[org.clojure/tools.cli "0.3.5"]
+                 [org.clojure/tools.namespace "0.2.6"]])


### PR DESCRIPTION
This was accidentally removed in #31.

Fixes #33